### PR TITLE
feature: Support of IJ 231

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ fun properties(key: String) = project.findProperty(key).toString()
 
 plugins {
   java
-  id("org.jetbrains.intellij") version "1.7.0"
+  id("org.jetbrains.intellij") version "1.13.0"
   id("org.jetbrains.grammarkit") version "2021.2.2"
   kotlin("jvm") version "1.7.10"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 platformType=IU
 platformVersion=202.6397.94
 pluginSinceBuild=202.6397
-pluginUntilBuild=223.*
+pluginUntilBuild=231.*
 
 # Needs a change-notes page with matching version in ./change-notes/
 # Also need to map the version to change-notes document

--- a/src/main/kotlin/com/github/lppedd/cc/editor/CommitTabAction.kt
+++ b/src/main/kotlin/com/github/lppedd/cc/editor/CommitTabAction.kt
@@ -1,5 +1,6 @@
 package com.github.lppedd.cc.editor
 
+import com.github.lppedd.cc.annotation.Compatibility
 import com.github.lppedd.cc.getCaretOffset
 import com.github.lppedd.cc.language.ConventionalCommitLanguage
 import com.github.lppedd.cc.language.psi.*
@@ -30,6 +31,10 @@ internal class CommitTabAction : TabAction() {
   private object CommitTabHandler : Handler() {
     private val moveCaretKey = Key.create<Int>("Vcs.CommitMessage.moveCaret")
 
+    @Compatibility(description = """
+      This method's signature has changed overtime in the Platform.
+      to executeWriteAction(Editor, Caret, DataContext) i.e. non nullable Caret.
+    """)
     override fun executeWriteAction(editor: Editor, caret: Caret?, dataContext: DataContext) {
       val steps = editor.getUserData(moveCaretKey)
 

--- a/src/main/kotlin/com/github/lppedd/cc/ui/NoContentTabbedPaneWrapper.kt
+++ b/src/main/kotlin/com/github/lppedd/cc/ui/NoContentTabbedPaneWrapper.kt
@@ -49,14 +49,11 @@ class NoContentTabbedPaneWrapper(disposable: Disposable) : TabbedPaneWrapper(dis
     }
 
     override fun propertyChange(event: PropertyChangeEvent) {
-      // TODO: maybe there is a less hacky way
-      if (event.propertyName == JBUIScale.USER_SCALE_FACTOR_PROPERTY) {
-        invokeLaterOnEdt {
-          @Suppress("UnstableApiUsage")
-          IdeEventQueue.getInstance().flushQueue()
-          revalidate()
-          repaint()
-        }
+      invokeLaterOnEdt {
+        @Suppress("UnstableApiUsage")
+        IdeEventQueue.getInstance().flushQueue()
+        revalidate()
+        repaint()
       }
     }
 


### PR DESCRIPTION
Since changes in 231 are now in a dedicated branch. It feels the right time to fix #108.

The changes are small, `TabAction.Handler` of the platform was converted to Kotlin in 231, and their nullity is now checked by the kotlin compiler.

However `JBUIScale` was converted in 223, but the property `USER_SCALE_FACTOR_PROPERTY` became private, instead of relying on reflection, I noticed that `JBUIScale` property listener is only fired on this single property before kotlin conversion and after. So I removed the check.