### PR TITLE
Possibly fix #113 by reducing the lock contention on `InternalVcsService`

### DIFF
--- a/src/main/kotlin/com/github/lppedd/cc/vcs/InternalVcsService.kt
+++ b/src/main/kotlin/com/github/lppedd/cc/vcs/InternalVcsService.kt
@@ -81,13 +81,12 @@ internal class InternalVcsService(private val project: Project) : VcsService {
   }
 
   private fun refreshCachedValues() {
-    cachedCurrentUserLock.write {
-      cachedCurrentUser = fetchCurrentUsers()
-    }
+    // fetch methods are executed outside the write locks to reduce the _write lock_ acquisition time
+    val refreshedCurrentUsers = fetchCurrentUsers()
+    cachedCurrentUserLock.write { cachedCurrentUser = refreshedCurrentUsers }
 
-    cachedCommitsLock.write {
-      cachedCommits = fetchCommits(sortBy = VcsCommitMetadata::getCommitTime)
-    }
+    val refreshedCommits = fetchCommits(sortBy = VcsCommitMetadata::getCommitTime)
+    cachedCommitsLock.write { cachedCommits = refreshedCommits }
   }
 
   private fun fetchCurrentUsers(): Set<VcsUser> =

--- a/src/main/kotlin/com/github/lppedd/cc/vcs/InternalVcsService.kt
+++ b/src/main/kotlin/com/github/lppedd/cc/vcs/InternalVcsService.kt
@@ -18,9 +18,6 @@ import com.intellij.vcs.log.visible.filters.VcsLogFilterObject
 import org.jetbrains.annotations.ApiStatus.*
 import java.util.*
 import java.util.Collections.newSetFromMap
-import java.util.concurrent.locks.ReentrantReadWriteLock
-import kotlin.concurrent.read
-import kotlin.concurrent.write
 import kotlin.io.path.notExists
 
 /**
@@ -35,11 +32,11 @@ internal class InternalVcsService(private val project: Project) : VcsService {
   private val vcsLogMultiRepoJoiner = VcsLogMultiRepoJoiner<Hash, VcsCommitMetadata>()
   private val subscribedVcsLogProviders = newSetFromMap<VcsLogProvider>(IdentityHashMap(16))
 
+  @Volatile
   private var cachedCurrentUser: Collection<VcsUser> = emptyList()
-  private val cachedCurrentUserLock = ReentrantReadWriteLock()
 
+  @Volatile
   private var cachedCommits: Collection<VcsCommitMetadata> = emptyList()
-  private val cachedCommitsLock = ReentrantReadWriteLock()
 
   override fun refresh() {
     val vcsLogProviders = getVcsLogProviders()
@@ -66,27 +63,17 @@ internal class InternalVcsService(private val project: Project) : VcsService {
     }
   }
 
-  override fun getCurrentUsers(): Collection<VcsUser> =
-    cachedCurrentUserLock.read {
-      cachedCurrentUser
-    }
+  override fun getCurrentUsers(): Collection<VcsUser> = cachedCurrentUser
 
-  override fun getOrderedTopCommits(): Collection<VcsCommitMetadata> =
-    cachedCommitsLock.read {
-      cachedCommits
-    }
+  override fun getOrderedTopCommits(): Collection<VcsCommitMetadata> = cachedCommits
 
   override fun addListener(listener: VcsListener) {
     refreshListeners.add(listener)
   }
 
   private fun refreshCachedValues() {
-    // fetch methods are executed outside the write locks to reduce the _write lock_ acquisition time
-    val refreshedCurrentUsers = fetchCurrentUsers()
-    cachedCurrentUserLock.write { cachedCurrentUser = refreshedCurrentUsers }
-
-    val refreshedCommits = fetchCommits(sortBy = VcsCommitMetadata::getCommitTime)
-    cachedCommitsLock.write { cachedCommits = refreshedCommits }
+    cachedCurrentUser = fetchCurrentUsers()
+    cachedCommits = fetchCommits(sortBy = VcsCommitMetadata::getCommitTime)
   }
 
   private fun fetchCurrentUsers(): Set<VcsUser> =


### PR DESCRIPTION

This commit should fix #113 where the `ClearLocalMessageHistoryAction.update` was causing a `PluginException: 316 ms to call on EDT` because the `InternalVcsService` was slow to get created.

The reason is that the creation happened on EDT, but the thread couldn't progress because there was a lock. The idea here is to reduce the contention by moving the heavy computation outside the write lock.

Fixes #113
For more details look at #113 
